### PR TITLE
Install safety_controller_node on catkin install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,11 +172,10 @@ install(TARGETS safety_controller_node
 )
 
 ## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+)
 
 ## Mark other files for installation (e.g. launch and bag files, etc.)
 # install(FILES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,11 +165,11 @@ add_dependencies(safety_controller_node ${PROJECT_NAME}_gencfg)
 # )
 
 # Mark executables and/or libraries for installation
-# install(TARGETS safety_controller safety_controller_node
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
+install(TARGETS safety_controller_node
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 ## Mark cpp header files for installation
 # install(DIRECTORY include/${PROJECT_NAME}/


### PR DESCRIPTION
Otherwise the binary is not accessible if the build/devel directories
are not in ROSPATH.

In particular, this allows building the package, installing it, and
removing all build and devel files afterwards.