### PR TITLE
Add side prioritization feature

### DIFF
--- a/include/safety_controller/safety_controller_node.h
+++ b/include/safety_controller/safety_controller_node.h
@@ -82,6 +82,12 @@ class SafetyController {
 
   double min_vel_, max_vel_, med_vel_, low_vel_, max_vel_theta_;
   double med_dist_, low_dist_;
+  bool prioritize_right_side_;
+  float cur_max_allowed_vel_;
+  float cur_range_;
+  bool is_left_sided_beam_;
+  int num_beams_half_;
+
 };
 };  // namespace safety_controller
 #endif


### PR DESCRIPTION
This adds a new feature that sets the `low_vel` only in case laser beams are lower than the `low_vel_dist` threshold and found on the left side of the respective sensor frame.
If they are lower than `low_vel_dist` but on the right side (and no others on the left side closer than `low_vel_dist`) the `med_vel_dist` is considered to be the maximum allowed velocity.

This allows robots in a multi-agent scenario to pass each other and help solve some situations where robots oscillate in front of each other.

Note that by default this feature is disabled.